### PR TITLE
[FEAT] 특정 가게의 리뷰 목록 조회 API 구현

### DIFF
--- a/src/main/java/umc/spring/converter/MemberConverter.java
+++ b/src/main/java/umc/spring/converter/MemberConverter.java
@@ -18,7 +18,7 @@ public class MemberConverter {
                 .build();
     }
 
-    public static Member toMember(MemberRequestDTO.JoinDTO request) {
+    public static Member toMember(MemberRequestDTO.JoinMemberDTO request) {
         Gender gender = switch (request.getGender()) {
             case 1 -> Gender.MALE;
             case 2 -> Gender.FEMALE;

--- a/src/main/java/umc/spring/converter/ReviewConverter.java
+++ b/src/main/java/umc/spring/converter/ReviewConverter.java
@@ -1,13 +1,17 @@
 package umc.spring.converter;
 
+import org.springframework.data.domain.Page;
 import umc.spring.domain.Review;
 import umc.spring.web.dto.ReviewRequestDTO;
 import umc.spring.web.dto.ReviewResponseDTO;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ReviewConverter {
 
+    // 리뷰로 변환
     public static Review toReview(ReviewRequestDTO.ReviewCreateDTO request) {
         return Review.builder()
                 .content(request.getBody())
@@ -15,10 +19,36 @@ public class ReviewConverter {
                 .build();
     }
 
+    // 리뷰 작성 DTO로 변환
     public static ReviewResponseDTO.ReviewCreateResultDTO toCreateReviewResultDTO(Review review) {
         return ReviewResponseDTO.ReviewCreateResultDTO.builder()
                 .reviewId(review.getId())
                 .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    // 리뷰 정보
+    public static ReviewResponseDTO.ReviewPreViewDTO reviewPreViewDTO(Review review) {
+        return ReviewResponseDTO.ReviewPreViewDTO.builder()
+                .ownerNickname(review.getMember().getName())
+                .score(review.getStar())
+                .body(review.getContent())
+                .createdAt(review.getCreatedAt().toLocalDate())
+                .build();
+    }
+
+    // 리뷰 목록
+    public static ReviewResponseDTO.ReviewPreViewListDTO reviewPreViewListDTO(Page<Review> reviewList) {
+        List<ReviewResponseDTO.ReviewPreViewDTO> reviewPreViewDTOList = reviewList.stream()
+                .map(ReviewConverter::reviewPreViewDTO).toList();
+
+        return ReviewResponseDTO.ReviewPreViewListDTO.builder()
+                .isFirst(reviewList.isFirst())
+                .isLast(reviewList.isLast())
+                .totalPage(reviewList.getTotalPages())
+                .totalElements(reviewList.getTotalElements())
+                .listSize(reviewPreViewDTOList.size())
+                .reviewList(reviewPreViewDTOList)
                 .build();
     }
 }

--- a/src/main/java/umc/spring/converter/StoreConverter.java
+++ b/src/main/java/umc/spring/converter/StoreConverter.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 
 public class StoreConverter {
 
-    public static Store toStore(StoreRequestDTO.JoinDTO request) {
+    public static Store toStore(StoreRequestDTO.JoinStoreDTO request) {
         return Store.builder()
                 .name(request.getName())
                 .address(request.getAddress())

--- a/src/main/java/umc/spring/repository/reviewRepository/ReviewRepository.java
+++ b/src/main/java/umc/spring/repository/reviewRepository/ReviewRepository.java
@@ -1,7 +1,12 @@
 package umc.spring.repository.reviewRepository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.spring.domain.Review;
+import umc.spring.domain.Store;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Page<Review> findAllByStore(Store store, PageRequest pageRequest);
 }

--- a/src/main/java/umc/spring/service/memberService/MemberCommandService.java
+++ b/src/main/java/umc/spring/service/memberService/MemberCommandService.java
@@ -6,7 +6,7 @@ import umc.spring.web.dto.MemberRequestDTO;
 import umc.spring.web.dto.MissionRequestDTO;
 
 public interface MemberCommandService {
-    Member joinMember(MemberRequestDTO.JoinDTO request);
+    Member joinMember(MemberRequestDTO.JoinMemberDTO request);
 
     MemberMission challengeMission(Long memberId, Long missionId, MissionRequestDTO.MissionChallengeDTO request);
 }

--- a/src/main/java/umc/spring/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/memberService/MemberCommandServiceImpl.java
@@ -38,7 +38,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
-    public Member joinMember(MemberRequestDTO.JoinDTO request) {
+    public Member joinMember(MemberRequestDTO.JoinMemberDTO request) {
 
         Member newMember = MemberConverter.toMember(request);
 

--- a/src/main/java/umc/spring/service/storeService/StoreCommandService.java
+++ b/src/main/java/umc/spring/service/storeService/StoreCommandService.java
@@ -7,7 +7,7 @@ import umc.spring.web.dto.StoreRequestDTO;
 
 public interface StoreCommandService {
 
-    Store joinStore(StoreRequestDTO.JoinDTO request);
+    Store joinStore(StoreRequestDTO.JoinStoreDTO request);
 
     Review createReview(Long memberId, Long storeId, ReviewRequestDTO.ReviewCreateDTO request);
 }

--- a/src/main/java/umc/spring/service/storeService/StoreCommandServiceImpl.java
+++ b/src/main/java/umc/spring/service/storeService/StoreCommandServiceImpl.java
@@ -25,7 +25,7 @@ public class StoreCommandServiceImpl implements StoreCommandService {
 
     @Override
     @Transactional
-    public Store joinStore(StoreRequestDTO.JoinDTO request) {
+    public Store joinStore(StoreRequestDTO.JoinStoreDTO request) {
         Store newStore = StoreConverter.toStore(request);
         return storeRepository.save(newStore);
     }

--- a/src/main/java/umc/spring/service/storeService/StoreQueryService.java
+++ b/src/main/java/umc/spring/service/storeService/StoreQueryService.java
@@ -1,5 +1,7 @@
 package umc.spring.service.storeService;
 
+import org.springframework.data.domain.Page;
+import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 
 import java.util.List;
@@ -10,4 +12,6 @@ public interface StoreQueryService {
     Optional<Store> findStore(Long id);
 
     List<Store> findStoresByNameAndScore(String name, Float score);
+
+    Page<Review> getReviewList(Long storeId, Integer page);
 }

--- a/src/main/java/umc/spring/service/storeService/StoreQueryServiceImpl.java
+++ b/src/main/java/umc/spring/service/storeService/StoreQueryServiceImpl.java
@@ -1,9 +1,13 @@
 package umc.spring.service.storeService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.spring.domain.Review;
 import umc.spring.domain.Store;
+import umc.spring.repository.reviewRepository.ReviewRepository;
 import umc.spring.repository.storeRepository.StoreRepository;
 
 import java.util.List;
@@ -15,6 +19,8 @@ import java.util.Optional;
 public class StoreQueryServiceImpl implements StoreQueryService {
 
     private final StoreRepository storeRepository;
+
+    private final ReviewRepository reviewRepository;
 
     @Override
     public Optional<Store> findStore(Long id) {
@@ -28,5 +34,13 @@ public class StoreQueryServiceImpl implements StoreQueryService {
         filteredStores.forEach(store -> System.out.println("Store: " + store));
 
         return filteredStores;
+    }
+
+    @Override
+    public Page<Review> getReviewList(Long storeId, Integer page) {
+        System.out.println("storeId = " + storeId);
+        Store store = storeRepository.findById(storeId).get();
+
+        return reviewRepository.findAllByStore(store, PageRequest.of(page, 10));
     }
 }

--- a/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -27,7 +27,7 @@ public class MemberRestController {
 
     @PostMapping
     @Operation(summary = "회원가입 API", description = "회원가입 API 입니다.")
-    public ApiResponse<MemberResponseDTO.JoinResultDTO> join(@RequestBody @Valid MemberRequestDTO.JoinDTO request) {
+    public ApiResponse<MemberResponseDTO.JoinResultDTO> joinMember(@RequestBody @Valid MemberRequestDTO.JoinMemberDTO request) {
         Member member = memberCommandService.joinMember(request);
         return ApiResponse.onSuccess(MemberConverter.toJoinResultDTO(member));
     }

--- a/src/main/java/umc/spring/web/controller/StoreRestController.java
+++ b/src/main/java/umc/spring/web/controller/StoreRestController.java
@@ -1,8 +1,14 @@
 package umc.spring.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.spring.apiPayload.ApiResponse;
@@ -14,6 +20,7 @@ import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 import umc.spring.service.missionService.MissionCommandService;
 import umc.spring.service.storeService.StoreCommandService;
+import umc.spring.service.storeService.StoreQueryService;
 import umc.spring.validation.annotation.ExistMember;
 import umc.spring.validation.annotation.ExistStore;
 import umc.spring.web.dto.*;
@@ -26,11 +33,13 @@ public class StoreRestController {
 
     private final StoreCommandService storeCommandService;
 
+    private final StoreQueryService storeQueryService;
+
     private final MissionCommandService missionCommandService;
 
     @PostMapping()
     @Operation(summary = "특정 지역에 가게 추가 API", description = "특정 지역에 가게를 추가하는 API 입니다.")
-    public ApiResponse<StoreResponseDTO.JoinResultDTO> joinStore(@Valid @RequestBody StoreRequestDTO.JoinDTO request) {
+    public ApiResponse<StoreResponseDTO.JoinResultDTO> joinStore(@Valid @RequestBody StoreRequestDTO.JoinStoreDTO request) {
         Store newStore = storeCommandService.joinStore(request);
         return ApiResponse.onSuccess(StoreConverter.toJoinResultDTO(newStore));
     }
@@ -52,5 +61,22 @@ public class StoreRestController {
             @Valid @RequestBody ReviewRequestDTO.ReviewCreateDTO request) {
         Review newReview = storeCommandService.createReview(storeId, memberId, request);
         return ApiResponse.onSuccess(ReviewConverter.toCreateReviewResultDTO(newReview));
+    }
+
+    @GetMapping("/{storeId}/reviews")
+    @Operation(summary = "특정 가게의 리뷰 목록 조회 API",
+            description = "특정 가게의 리뷰 목록을 조회하는 API이며, 페이징을 포함합니다. query string으로 page 번호를 주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "STORE4001", description = "해당 가게가 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
+    })
+    public ApiResponse<ReviewResponseDTO.ReviewPreViewListDTO> getReviewList(
+            @ExistStore @PathVariable("storeId") Long storeId,
+            @RequestParam("page") Integer page) {
+        Page<Review> reviewList = storeQueryService.getReviewList(storeId, page);
+        return ApiResponse.onSuccess(ReviewConverter.reviewPreViewListDTO(reviewList));
     }
 }

--- a/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class MemberRequestDTO {
 
     @Getter
-    public static class JoinDTO {
+    public static class JoinMemberDTO {
         @NotBlank
         String name;
         @NotNull

--- a/src/main/java/umc/spring/web/dto/ReviewResponseDTO.java
+++ b/src/main/java/umc/spring/web/dto/ReviewResponseDTO.java
@@ -5,10 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ReviewResponseDTO {
 
+    // 리뷰 작성
     @Builder
     @Getter
     @AllArgsConstructor
@@ -16,5 +19,31 @@ public class ReviewResponseDTO {
     public static class ReviewCreateResultDTO {
         Long reviewId;
         LocalDateTime createdAt;
+    }
+
+    // 리뷰 목록 조회
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReviewPreViewListDTO {
+        List<ReviewPreViewDTO> reviewList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    // 리뷰 목록에 담길 리뷰 정보
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReviewPreViewDTO {
+        String ownerNickname;
+        Float score;
+        String body;
+        LocalDate createdAt;
     }
 }

--- a/src/main/java/umc/spring/web/dto/StoreRequestDTO.java
+++ b/src/main/java/umc/spring/web/dto/StoreRequestDTO.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 public class StoreRequestDTO {
 
     @Getter
-    public static class JoinDTO {
+    public static class JoinStoreDTO {
         @NotBlank
         String name;
         @NotBlank @Size(min = 10, max = 100)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
 logging:
   level:


### PR DESCRIPTION
## Issue
#11 

## Description
 - DTO나 Controller 메서드 이름이 같은 경우 Swagger에 API가 제대로 표시되지 않음
   - 이름에 엔티티나 다른 단어를 추가해 겹치지 않도록 함
 - 특정 가게의 리뷰 목록을 조회하는 API 구현 (Page 페이징)